### PR TITLE
fix GetPositions issue

### DIFF
--- a/Metatrader/MQL5/Include/ejtraderMT/Broker.mqh
+++ b/Metatrader/MQL5/Include/ejtraderMT/Broker.mqh
@@ -7,9 +7,55 @@
 //| Fetch positions information                                      |
 //+------------------------------------------------------------------+
 void GetPositions(CJAVal &dataObject)
-  {
+{
    CPositionInfo myposition;
-   CJAVal data, position;
+   CJAVal data;
+
+   // Get positions
+   int positionsTotal=PositionsTotal();
+   
+   // Create empty array if no positions
+   if(!positionsTotal)
+   {
+      CJAVal emptyPosition;
+      data["positions"].Add(emptyPosition);
+   }
+      
+   // Go through positions in a loop
+   for(int i=0; i<positionsTotal; i++)
+   {
+      mControl.mResetLastError();
+      
+      // Get the position ticket directly by index
+      ulong ticket = PositionGetTicket(i);
+      
+      if(ticket && myposition.SelectByTicket(ticket))
+      {
+         // Create a new position object for each position
+         CJAVal position;
+         
+         position["id"]=PositionGetInteger(POSITION_IDENTIFIER);
+         position["magic"]=PositionGetInteger(POSITION_MAGIC);
+         position["symbol"]=PositionGetString(POSITION_SYMBOL);
+         position["type"]=EnumToString(ENUM_POSITION_TYPE(PositionGetInteger(POSITION_TYPE)));
+         position["time_setup"]=PositionGetInteger(POSITION_TIME);
+         position["open"]=PositionGetDouble(POSITION_PRICE_OPEN);
+         position["stoploss"]=PositionGetDouble(POSITION_SL);
+         position["takeprofit"]=PositionGetDouble(POSITION_TP);
+         position["volume"]=PositionGetDouble(POSITION_VOLUME);
+
+         data["positions"].Add(position);
+      }
+      CheckError(__FUNCTION__);
+   }
+   
+   data["error"]=(bool) false;
+   
+   string t=data.Serialize();
+   if(debug)
+      Print(t);
+   InformClientSocket(sysSocket,t);
+}
 
 // Get positions
    int positionsTotal=PositionsTotal();

--- a/Metatrader/MQL5/Include/ejtraderMT/Broker.mqh
+++ b/Metatrader/MQL5/Include/ejtraderMT/Broker.mqh
@@ -57,40 +57,6 @@ void GetPositions(CJAVal &dataObject)
    InformClientSocket(sysSocket,t);
 }
 
-// Get positions
-   int positionsTotal=PositionsTotal();
-// Create empty array if no positions
-   if(!positionsTotal)
-      data["positions"].Add(position);
-// Go through positions in a loop
-   for(int i=0; i<positionsTotal; i++)
-     {
-      mControl.mResetLastError();
-
-      if(myposition.Select(PositionGetSymbol(i)))
-        {
-         position["id"]=PositionGetInteger(POSITION_IDENTIFIER);
-         position["magic"]=PositionGetInteger(POSITION_MAGIC);
-         position["symbol"]=PositionGetString(POSITION_SYMBOL);
-         position["type"]=EnumToString(ENUM_POSITION_TYPE(PositionGetInteger(POSITION_TYPE)));
-         position["time_setup"]=PositionGetInteger(POSITION_TIME);
-         position["open"]=PositionGetDouble(POSITION_PRICE_OPEN);
-         position["stoploss"]=PositionGetDouble(POSITION_SL);
-         position["takeprofit"]=PositionGetDouble(POSITION_TP);
-         position["volume"]=PositionGetDouble(POSITION_VOLUME);
-
-         data["error"]=(bool) false;
-         data["positions"].Add(position);
-        }
-      CheckError(__FUNCTION__);
-     }
-
-   string t=data.Serialize();
-   if(debug)
-      Print(t);
-   InformClientSocket(sysSocket,t);
-  }
-
 //+------------------------------------------------------------------+
 //| Fetch orders information                                         |
 //+------------------------------------------------------------------+


### PR DESCRIPTION
Fix for these two critical issues in this code:

1. Symbol-based selection instead of index-based selection:
    - We're using `myposition.Select(PositionGetSymbol(i))` which selects a position by symbol
    - When we have multiple positions with the same symbol (e.g., EURUSD), this will always select the FIRST position with that symbol

1. Position object reuse:
    - The position `CJAVal` object is defined once outside the loop and reused


