### PR TITLE
fix GetPositions issue and add GetSymbolInfo

### DIFF
--- a/Metatrader/MQL5/Experts/ejtraderMT.mq5
+++ b/Metatrader/MQL5/Experts/ejtraderMT.mq5
@@ -31,6 +31,7 @@ Socket sysSocket(context, ZMQ_REP);
 #include <ejtraderMT/HistoryInfo.mqh>
 #include <ejtraderMT/Broker.mqh>
 #include <ejtraderMT/Calendar.mqh>
+#include <ejtraderMT/SymbolsInfo.mqh>
 
 // Global variables \\
 input bool debug = false;
@@ -317,6 +318,8 @@ void RequestHandler(ZmqMsg &request)
       ScriptConfiguration(incomingMessage);
    else if (action == "ACCOUNT")
       GetAccountInfo();
+   else if (action == "SYMBOLINFO")
+      GetSymbolInfo(incomingMessage);
    else if (action == "LISTSYMBOLS")
       GetSymbolsList();
    else if (action == "LISTSYMBOLSDETAILS")

--- a/Metatrader/MQL5/Include/ejtraderMT/Broker.mqh
+++ b/Metatrader/MQL5/Include/ejtraderMT/Broker.mqh
@@ -7,22 +7,33 @@
 //| Fetch positions information                                      |
 //+------------------------------------------------------------------+
 void GetPositions(CJAVal &dataObject)
-  {
+{
    CPositionInfo myposition;
-   CJAVal data, position;
+   CJAVal data;
 
-// Get positions
+   // Get positions
    int positionsTotal=PositionsTotal();
-// Create empty array if no positions
+   
+   // Create empty array if no positions
    if(!positionsTotal)
-      data["positions"].Add(position);
-// Go through positions in a loop
+   {
+      CJAVal emptyPosition;
+      data["positions"].Add(emptyPosition);
+   }
+      
+   // Go through positions in a loop
    for(int i=0; i<positionsTotal; i++)
-     {
+   {
       mControl.mResetLastError();
-
-      if(myposition.Select(PositionGetSymbol(i)))
-        {
+      
+      // Get the position ticket directly by index
+      ulong ticket = PositionGetTicket(i);
+      
+      if(ticket && myposition.SelectByTicket(ticket))
+      {
+         // Create a new position object for each position
+         CJAVal position;
+         
          position["id"]=PositionGetInteger(POSITION_IDENTIFIER);
          position["magic"]=PositionGetInteger(POSITION_MAGIC);
          position["symbol"]=PositionGetString(POSITION_SYMBOL);
@@ -33,17 +44,18 @@ void GetPositions(CJAVal &dataObject)
          position["takeprofit"]=PositionGetDouble(POSITION_TP);
          position["volume"]=PositionGetDouble(POSITION_VOLUME);
 
-         data["error"]=(bool) false;
          data["positions"].Add(position);
-        }
+      }
       CheckError(__FUNCTION__);
-     }
-
+   }
+   
+   data["error"]=(bool) false;
+   
    string t=data.Serialize();
    if(debug)
       Print(t);
    InformClientSocket(sysSocket,t);
-  }
+}
 
 //+------------------------------------------------------------------+
 //| Fetch orders information                                         |

--- a/Metatrader/MQL5/Include/ejtraderMT/Broker.mqh
+++ b/Metatrader/MQL5/Include/ejtraderMT/Broker.mqh
@@ -10,7 +10,7 @@ void GetPositions(CJAVal &dataObject)
 {
    CPositionInfo myposition;
    CJAVal data;
-
+   
    // Get positions
    int positionsTotal=PositionsTotal();
    

--- a/Metatrader/MQL5/Include/ejtraderMT/SymbolsInfo.mqh
+++ b/Metatrader/MQL5/Include/ejtraderMT/SymbolsInfo.mqh
@@ -1,0 +1,91 @@
+#property copyright "ejtrader"
+#property link      "https://github.com/ejtraderLabs/MQL5-ejtraderMT"
+
+void GetSymbolInfo(CJAVal &dataObject)
+{
+   mControl.mResetLastError();
+   
+   string symbol = dataObject["symbol"].ToStr();
+   
+   // Validate symbol exists
+   if(!SymbolSelect(symbol, true)) {
+      ActionDoneOrError(ERR_MARKET_UNKNOWN_SYMBOL, __FUNCTION__, "Symbol not found");
+      return;
+   }
+   
+   CJAVal symbolData;
+   
+   // General symbol info
+   symbolData["name"] = symbol;
+   symbolData["description"] = SymbolInfoString(symbol, SYMBOL_DESCRIPTION);
+   symbolData["currency_base"] = SymbolInfoString(symbol, SYMBOL_CURRENCY_BASE);
+   symbolData["currency_profit"] = SymbolInfoString(symbol, SYMBOL_CURRENCY_PROFIT);
+   symbolData["currency_margin"] = SymbolInfoString(symbol, SYMBOL_CURRENCY_MARGIN);
+   symbolData["type"] = GetSymbolType(symbol);
+   
+   // Prices
+   symbolData["bid"] = SymbolInfoDouble(symbol, SYMBOL_BID);
+   symbolData["ask"] = SymbolInfoDouble(symbol, SYMBOL_ASK);
+   symbolData["last"] = SymbolInfoDouble(symbol, SYMBOL_LAST);
+   symbolData["bidhigh"] = SymbolInfoDouble(symbol, SYMBOL_BIDHIGH);
+   symbolData["bidlow"] = SymbolInfoDouble(symbol, SYMBOL_BIDLOW);
+   symbolData["askhigh"] = SymbolInfoDouble(symbol, SYMBOL_ASKHIGH);
+   symbolData["asklow"] = SymbolInfoDouble(symbol, SYMBOL_ASKLOW);
+   symbolData["lasthigh"] = SymbolInfoDouble(symbol, SYMBOL_LASTHIGH);
+   symbolData["lastlow"] = SymbolInfoDouble(symbol, SYMBOL_LASTLOW);
+   
+   // Trade parameters
+   symbolData["point"] = SymbolInfoDouble(symbol, SYMBOL_POINT);
+   symbolData["digits"] = SymbolInfoInteger(symbol, SYMBOL_DIGITS);
+   symbolData["spread"] = SymbolInfoInteger(symbol, SYMBOL_SPREAD);
+   symbolData["spread_float"] = (bool)SymbolInfoInteger(symbol, SYMBOL_SPREAD_FLOAT);
+   
+   // Volume specifications
+   symbolData["volume_min"] = SymbolInfoDouble(symbol, SYMBOL_VOLUME_MIN);
+   symbolData["volume_max"] = SymbolInfoDouble(symbol, SYMBOL_VOLUME_MAX);
+   symbolData["volume_step"] = SymbolInfoDouble(symbol, SYMBOL_VOLUME_STEP);
+   symbolData["volume_limit"] = SymbolInfoDouble(symbol, SYMBOL_VOLUME_LIMIT);
+   
+   // Contract and tick info
+   symbolData["trade_contract_size"] = SymbolInfoDouble(symbol, SYMBOL_TRADE_CONTRACT_SIZE);
+   symbolData["trade_tick_size"] = SymbolInfoDouble(symbol, SYMBOL_TRADE_TICK_SIZE);
+   symbolData["trade_tick_value"] = SymbolInfoDouble(symbol, SYMBOL_TRADE_TICK_VALUE);
+   symbolData["trade_tick_value_profit"] = SymbolInfoDouble(symbol, SYMBOL_TRADE_TICK_VALUE_PROFIT);
+   symbolData["trade_tick_value_loss"] = SymbolInfoDouble(symbol, SYMBOL_TRADE_TICK_VALUE_LOSS);
+   
+   // Trade modes and restrictions
+   symbolData["trade_mode"] = EnumToString((ENUM_SYMBOL_TRADE_MODE)SymbolInfoInteger(symbol, SYMBOL_TRADE_MODE));
+   symbolData["trade_calc_mode"] = EnumToString((ENUM_SYMBOL_CALC_MODE)SymbolInfoInteger(symbol, SYMBOL_TRADE_CALC_MODE));
+   symbolData["trade_stops_level"] = SymbolInfoInteger(symbol, SYMBOL_TRADE_STOPS_LEVEL);
+   symbolData["trade_freeze_level"] = SymbolInfoInteger(symbol, SYMBOL_TRADE_FREEZE_LEVEL);
+   
+   // Swap information
+   symbolData["swap_mode"] = EnumToString((ENUM_SYMBOL_SWAP_MODE)SymbolInfoInteger(symbol, SYMBOL_SWAP_MODE));
+   symbolData["swap_long"] = SymbolInfoDouble(symbol, SYMBOL_SWAP_LONG);
+   symbolData["swap_short"] = SymbolInfoDouble(symbol, SYMBOL_SWAP_SHORT);
+   symbolData["swap_rollover3days"] = EnumToString((ENUM_DAY_OF_WEEK)SymbolInfoInteger(symbol, SYMBOL_SWAP_ROLLOVER3DAYS));
+   
+   // Session information
+   symbolData["session_volume"] = SymbolInfoDouble(symbol, SYMBOL_SESSION_VOLUME);
+   symbolData["session_deals"] = SymbolInfoInteger(symbol, SYMBOL_SESSION_DEALS);
+   symbolData["session_buy_orders"] = SymbolInfoInteger(symbol, SYMBOL_SESSION_BUY_ORDERS);
+   symbolData["session_sell_orders"] = SymbolInfoInteger(symbol, SYMBOL_SESSION_SELL_ORDERS);
+   
+   // Expiration information (for futures/options)
+   datetime expiration;
+   if(SymbolInfoInteger(symbol, SYMBOL_EXPIRATION_TIME, expiration))
+      symbolData["expiration_time"] = (long)expiration;
+   
+   symbolData["margin_hedged_use_leg"] = (bool)SymbolInfoInteger(symbol, SYMBOL_MARGIN_HEDGED_USE_LEG);
+   symbolData["order_mode"] = SymbolInfoInteger(symbol, SYMBOL_ORDER_MODE);
+   symbolData["filling_mode"] = SymbolInfoInteger(symbol, SYMBOL_FILLING_MODE);
+   
+   CJAVal data;
+   data["error"] = (bool)false;
+   data["data"].Set(symbolData);
+   
+   string t = data.Serialize();
+   if(debug)
+      Print(t);
+   InformClientSocket(sysSocket, t);
+}


### PR DESCRIPTION
**Fix for these two critical issues in this code:**
1. Symbol-based selection instead of index-based selection:
    - We're using `myposition.Select(PositionGetSymbol(i))` which selects a position by symbol
    - When we have multiple positions with the same symbol (e.g., EURUSD), this will always select the FIRST position with that symbol

1. Position object reuse:
    - The position `CJAVal` object is defined once outside the loop and reused

**New SYMBOLINFO Action:**
1. Added a GetSymbolInfo function to retrieve detailed information about a specific symbol.
2. Implemented in the RequestHandler to process SYMBOLINFO requests.
3. Returns comprehensive symbol data including general info, prices, trade parameters, volume specifications, contract details, trade modes, swap information, and more.